### PR TITLE
Fix build in Ayatana

### DIFF
--- a/tray_linux.c
+++ b/tray_linux.c
@@ -3,6 +3,8 @@
 #include <stddef.h>
 #ifdef TRAY_AYATANA_APPINDICATOR
 #include <libayatana-appindicator/app-indicator.h>
+/*Ayatana flavor of appindicator has a different name for the same Macro*/
+#define IS_APP_INDICATOR APP_IS_INDICATOR 
 #elif TRAY_LEGACY_APPINDICATOR
 #include <libappindicator/app-indicator.h>
 #endif


### PR DESCRIPTION
## Description
Ayatana-libappindicator has a different Macro name than libappindicator. Should fix build that was broken on arch after commit b7a02efb851fcaabdba0cc26552d2de6b9d37bde

