### PR TITLE
Allow tray icons to be precached.

### DIFF
--- a/tray.h
+++ b/tray.h
@@ -16,6 +16,8 @@ struct tray {
   const char *notification_title;
   void (*notification_cb)();
   struct tray_menu *menu;
+  const int iconPathCount;
+  const char *allIconPaths[];
 };
 
 struct tray_menu {


### PR DESCRIPTION
## Description
On Windows, loading icons through the shell API can trigger DRM issues, leading to windows becoming invisible. This changelist works around these issues by preloading icons at initialization and avoiding calling the shell API methods on demand.

### Screenshot
The change should be transparent to the user. No behav


### Issues Fixed or Closed
This brings submodule support for enabling a subsequent change which will resolve [this issue](https://github.com/LizardByte/Sunshine/issues/2092).


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
