### PR TITLE
Fix for missing small icon infinite recursion

### DIFF
--- a/tray_windows.c
+++ b/tray_windows.c
@@ -111,7 +111,12 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
 struct icon_info _create_icon_info(const char * path) {
   struct icon_info info;
   info.path = strdup(path);
-  ExtractIconEx(path, 0, &info.large_icon, &info.icon, 1);
+
+  // These must be separate invocations otherwise Windows may opt to only return large or small icons.
+  // MSDN does not explicitly state this anywhere, but it has been observed on some machines.
+  ExtractIconEx(path, 0, &info.large_icon, NULL, 1);
+  ExtractIconEx(path, 0, NULL, &info.icon, 1);
+
   info.notification_icon = LoadImageA(NULL, path, IMAGE_ICON, GetSystemMetrics(SM_CXICON) * 2, GetSystemMetrics(SM_CYICON) * 2, LR_LOADFROMFILE);
   return info;
 }

--- a/tray_windows.c
+++ b/tray_windows.c
@@ -110,7 +110,7 @@ static HMENU _tray_menu(struct tray_menu *m, UINT *id) {
 
 struct icon_info _create_icon_info(const char * path) {
   struct icon_info info;
-  info.path = path;
+  info.path = strdup(path);
   ExtractIconEx(path, 0, &info.large_icon, &info.icon, 1);
   info.notification_icon = LoadImageA(NULL, path, IMAGE_ICON, GetSystemMetrics(SM_CXICON) * 2, GetSystemMetrics(SM_CYICON) * 2, LR_LOADFROMFILE);
   return info;
@@ -130,6 +130,7 @@ void _destroy_icon_cache() {
     DestroyIcon(icon_infos[i].icon);
     DestroyIcon(icon_infos[i].large_icon);
     DestroyIcon(icon_infos[i].notification_icon);
+    free((void*) icon_infos[i].path);
   }
 
   free(icon_infos);

--- a/tray_windows.c
+++ b/tray_windows.c
@@ -143,28 +143,23 @@ void _destroy_icon_cache() {
   icon_info_count = 0;
 }
 
-HICON _fetch_cached_icon(const char * path, enum IconType icon_type) {
-  for (int i = 0; i < icon_info_count; ++i) {
-    if (strcmp(icon_infos[i].path, path) == 0) {
-      switch (icon_type) {
-        case REGULAR:
-          return icon_infos[i].icon;
-        case LARGE:
-          return icon_infos[i].large_icon;
-        case NOTIFICATION:
-          return icon_infos[i].notification_icon;
-      }
-    }
+HICON _fetch_cached_icon(struct icon_info *icon_record, enum IconType icon_type) {
+  switch (icon_type) {
+    case REGULAR:
+      return icon_record->icon;
+    case LARGE:
+      return icon_record->large_icon;
+    case NOTIFICATION:
+      return icon_record->notification_icon;
   }
-
-  return NULL;
 }
 
 HICON _fetch_icon(const char * path, enum IconType icon_type) {
-  HICON value = _fetch_cached_icon(path, icon_type);
-
-  if (value != NULL) {
-    return value;
+  // Find a cached icon by path
+  for (int i = 0; i < icon_info_count; ++i) {
+    if (strcmp(icon_infos[i].path, path) == 0) {
+      return _fetch_cached_icon(&icon_infos[i], icon_type);
+    }
   }
 
   // Expand cache, fetch, and retry
@@ -173,7 +168,7 @@ HICON _fetch_icon(const char * path, enum IconType icon_type) {
   int index = icon_info_count - 1;
   icon_infos[icon_info_count - 1] = _create_icon_info(path);
 
-  return _fetch_icon(path, icon_type);
+  return _fetch_cached_icon(&icon_infos[icon_info_count - 1], icon_type);
 }
 
 int tray_init(struct tray *tray) {


### PR DESCRIPTION
## Description
This PR fixes a few issues with the icon caching:
- Not properly managing the lifetime of the `path` string in the cache entries
- The cached small icon being NULL on some machines
- Infinite recursion if icon load fails for any persistent reason

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
