### PR TITLE
fix(linux): replace deprecated app_indicator_set_icon call

### DIFF
--- a/src/tray_linux.c
+++ b/src/tray_linux.c
@@ -80,7 +80,7 @@ static gboolean tray_update_internal(gpointer user_data) {
   struct tray *tray = user_data;
 
   if(indicator != NULL && IS_APP_INDICATOR(indicator)){
-    app_indicator_set_icon(indicator, tray->icon);
+    app_indicator_set_icon_full(indicator, tray->icon, tray->icon);
     // GTK is all about reference counting, so previous menu should be destroyed
     // here
     app_indicator_set_menu(indicator, GTK_MENU(_tray_menu(tray->menu)));


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`app_indicator_set_icon` is deprecated, use `app_indicator_set_icon_full` instead.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
