### PR TITLE
fix: build tests and docs only if main project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,9 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 #
 # Project optional configuration
 #
-option(BUILD_DOCS "Build documentation" ON)
-option(BUILD_TESTS "Build tests" ON)
-
-#
-# Documentation
-#
-if(BUILD_DOCS)
-    add_subdirectory(third-party/doxyconfig docs)
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(BUILD_DOCS "Build documentation" ON)
+    option(BUILD_TESTS "Build tests" ON)
 endif()
 
 # Generate 'compile_commands.json' for clang_complete
@@ -107,7 +102,25 @@ target_compile_options(${PROJECT_NAME} PRIVATE ${TRAY_COMPILE_OPTIONS})
 target_link_directories(${PROJECT_NAME} PRIVATE ${TRAY_EXTERNAL_DIRECTORIES})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${TRAY_EXTERNAL_LIBRARIES})
 
-# tests
-if(BUILD_TESTS)
-    add_subdirectory(tests)
+#
+# Testing and documentation are only available if this is the main project
+#
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    if(BUILD_DOCS)
+        add_subdirectory(third-party/doxyconfig docs)
+    endif()
+
+    if(BUILD_TESTS)
+        #
+        # Additional setup for coverage
+        # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
+        #
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -O0")
+            set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -O0")
+        endif()
+
+        enable_testing()
+        add_subdirectory(tests)
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,8 +116,8 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         # https://gcovr.com/en/stable/guide/compiling.html#compiler-options
         #
         if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-            set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -O0")
-            set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -O0")
+            set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
+            set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
         endif()
 
         enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,19 +5,12 @@ project(test_tray)
 
 include_directories("${CMAKE_SOURCE_DIR}")
 
-enable_testing()
-
 # Add GoogleTest directory to the project
 set(GTEST_SOURCE_DIR "${CMAKE_SOURCE_DIR}/third-party/googletest")
 set(INSTALL_GTEST OFF)
 set(INSTALL_GMOCK OFF)
 add_subdirectory("${GTEST_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/googletest")
 include_directories("${GTEST_SOURCE_DIR}/googletest/include" "${GTEST_SOURCE_DIR}")
-
-# coverage
-# https://gcovr.com/en/stable/guide/compiling.html#compiler-options
-set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
-set(CMAKE_C_FLAGS "-fprofile-arcs -ftest-coverage -ggdb -O0")
 
 # if windows
 if (WIN32)


### PR DESCRIPTION
## Description
Build tests and docs only if main project. Also applied some fixes from libdisplaydevice.

Removed the `-ggdb` flag as I could not find it anywhere in the provided link...

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
