### PR TITLE
refactor: Move platform specific code from QtTrayMenu to tray_linux

### DIFF
--- a/src/QtTrayMenu.cpp
+++ b/src/QtTrayMenu.cpp
@@ -27,11 +27,6 @@ QtTrayMenu::QtTrayMenu(QObject *parent, const bool debug):
 
 QtTrayMenu::QtTrayMenu(int argc, char **argv, QObject *parent, const bool debug):
     QObject(parent) {
-  if (qgetenv("WAYLAND_DISPLAY").isEmpty() && qgetenv("DISPLAY").isEmpty()) {
-    // Force fallback to QT platform minimal if no (WAYLAND_)DISPLAY was found
-    qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("minimal"));
-    qWarning("QtTrayMenu: no reachable WAYLAND_DISPLAY or DISPLAY endpoint, forcing QT_QPA_PLATFORM=minimal");
-  }
   if (QApplication::instance()) {
     app = dynamic_cast<QApplication *>(QApplication::instance());
     if (!app) {

--- a/src/tray_linux.cpp
+++ b/src/tray_linux.cpp
@@ -176,6 +176,12 @@ extern "C" {
 
   int tray_init(struct tray *tray) {
     if (tray_linux::qt_tray_menu == nullptr) {
+      // Check if a (wayland_)display is set or fallback to minimal QPA platform
+      if (qgetenv("WAYLAND_DISPLAY").isEmpty() && qgetenv("DISPLAY").isEmpty()) {
+        // Force fallback to QT platform minimal if no (WAYLAND_)DISPLAY was found
+        qputenv("QT_QPA_PLATFORM", QByteArrayLiteral("minimal"));
+        qWarning("QtTrayMenu: no reachable WAYLAND_DISPLAY or DISPLAY endpoint, forcing QT_QPA_PLATFORM=minimal");
+      }
       // Create a new unique pointer to QtTrayMenu instance
       tray_linux::qt_tray_menu = std::make_unique<QtTrayMenu>();
     }


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Currently QtTrayMenu checks for WAYLAND_DISPLAY or x11 DISPLAY and sets QT_QPA_PLATFORM if neither is found. This is a linux platform specific workaround that needs moving to tray_linux for QtTrayMenu to be platform independent.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [X] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
