### PR TITLE
fix(linux): break QtMainLoop on exit if loop() was called blocking

### DIFF
--- a/src/QtTrayMenu.cpp
+++ b/src/QtTrayMenu.cpp
@@ -112,7 +112,7 @@ void QtTrayMenu::onUpdate(struct tray *tray, const bool notify) {
   }
 }
 
-int QtTrayMenu::loop(int blocking) const {
+int QtTrayMenu::loop(int blocking) {
   if (!running) {
     return -1;
   }
@@ -121,9 +121,11 @@ int QtTrayMenu::loop(int blocking) const {
     return -1;
   }
   if (blocking) {
+    blockingEventLoop = true;
     QApplication::exec();
     return -1;
   } else {
+    blockingEventLoop = false;
     QApplication::processEvents();
     return 0;
   }
@@ -149,6 +151,11 @@ void QtTrayMenu::onExitRequested() {
   }
   // Unset tray structure
   trayStruct = nullptr;
+
+  // If we run in a blocking event loop break said loop by quitting the QApplication
+  if (blockingEventLoop) {
+    QApplication::quit();
+  }
 }
 
 void QtTrayMenu::updateMenu(struct tray_menu *items) {

--- a/src/QtTrayMenu.h
+++ b/src/QtTrayMenu.h
@@ -60,7 +60,7 @@ public:
    * @param blocking if true the function call will block until QtTrayMenu exits
    * @return 0 on successful processing if non-blocking, -1 otherwise
    */
-  int loop(int blocking) const;
+  int loop(int blocking);
 
   /**
    * @brief Configure metadata for QApplication
@@ -135,6 +135,7 @@ private:
   QMenu *trayTopMenu = nullptr;
   struct tray *trayStruct = nullptr;
   bool running = false;
+  bool blockingEventLoop = false;
   struct tray_menu *getTrayMenuItem(QAction *action);
   std::function<void()> notificationCallback = nullptr;
 


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
This is a cleaner variant of #138 that only breaks the QtMainLoop via `QApplication::quit` when it was started during `loop(1)` via `QApplication::exec`. This was missing before causing the QtMainLoop to continue running until the QtTrayMenu object was destroyed eventually and not when tray_exit was called hence the `loop(1)` call never returning blocking the calling thread.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
 - Closes #138 


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [X] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [ ] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [X] Code follows the style guidelines of this project
- [X] Code has been self-reviewed
- [X] Code has been commented, particularly in hard-to-understand areas
- [ ] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [ ] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
- [X] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
