### PR TITLE
test: add mouse positioning helpers for tray icon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           dependencies=(
+            "cliclick"
             "cmake"
             "doxygen"
             "graphviz"
@@ -123,10 +124,12 @@ jobs:
           )
           brew install "${dependencies[@]}"
 
-      - name: Fix macOS screen recording permissions
+      - name: Configure macOS screen recording
         if: runner.os == 'macOS'
         run: |
           set -euo pipefail
+
+          clickTool="$(command -v cliclick)"
 
           configure_system_tccdb() {
             local values=$1
@@ -144,6 +147,8 @@ jobs:
 
           systemValuesArray=(
             "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
+            "'kTCCServicePostEvent','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
+            "'kTCCServicePostEvent','$clickTool',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1599831148"
           )
           for values in "${systemValuesArray[@]}"; do
             configure_system_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
@@ -151,12 +156,20 @@ jobs:
 
           userValuesArray=(
             "'kTCCServiceScreenCapture','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+            "'kTCCServicePostEvent','/bin/bash',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
+            "'kTCCServicePostEvent','$clickTool',1,2,0,1,NULL,NULL,NULL,'UNUSED',NULL,0,1583997993"
           )
           for values in "${userValuesArray[@]}"; do
             configure_user_tccdb "$values,NULL,NULL,'UNUSED',${values##*,}"
           done
 
-          echo "macOS TCC permissions configured."
+          preflightScreenshot="$RUNNER_TEMP/screen-capture-preflight.png"
+          screencapture -x "$preflightScreenshot"
+          sleep 1
+          "$clickTool" kp:return
+          sleep 1
+
+          echo "macOS screen recording configured."
 
       - name: Setup Dependencies Windows
         if: runner.os == 'Windows'

--- a/src/QtTrayMenu.cpp
+++ b/src/QtTrayMenu.cpp
@@ -342,3 +342,41 @@ void QtTrayMenu::clickMessage() const {
 void QtTrayMenu::clearMessageCallback() const {
   notificationCallback = nullptr;
 }
+
+bool QtTrayMenu::positionMouseOverIcon() {
+  if (!trayIcon) {
+    return false;
+  }
+
+  const QRect iconGeometry = trayIcon->geometry();
+  if (!iconGeometry.isValid()) {
+    qWarning("QtTrayMenu: tray icon geometry is unavailable");
+    return false;
+  }
+
+  if (!mousePositionSaved) {
+    savedMousePosition = QCursor::pos();
+    mousePositionSaved = true;
+  }
+  const QPoint targetPosition = iconGeometry.center();
+  QCursor::setPos(targetPosition);
+  const bool positioned = QCursor::pos() == targetPosition;
+  if (!positioned) {
+    qWarning("QtTrayMenu: could not position the mouse over the tray icon");
+  }
+  return positioned;
+}
+
+bool QtTrayMenu::restoreMousePosition() {
+  if (!mousePositionSaved) {
+    return false;
+  }
+
+  QCursor::setPos(savedMousePosition);
+  mousePositionSaved = false;
+  const bool restored = QCursor::pos() == savedMousePosition;
+  if (!restored) {
+    qWarning("QtTrayMenu: could not restore the saved mouse position");
+  }
+  return restored;
+}

--- a/src/QtTrayMenu.cpp
+++ b/src/QtTrayMenu.cpp
@@ -10,6 +10,7 @@
 #include <QCursor>
 #include <QDebug>
 #include <QMouseEvent>
+#include <QScreen>
 #include <QStyle>
 
 // local includes
@@ -18,6 +19,46 @@
 #if defined(_WIN32)
   #include "WindowsAppearance.h"
 #endif
+
+namespace {
+  constexpr int DEFAULT_PANEL_THICKNESS = 24;
+  constexpr int CURSOR_POSITION_TOLERANCE = 2;
+
+  bool positionsAreClose(const QPoint &first, const QPoint &second) {
+    return (first - second).manhattanLength() <= CURSOR_POSITION_TOLERANCE;
+  }
+
+  bool fallbackTrayIconPosition(QPoint *position) {
+    const QScreen *screen = QGuiApplication::primaryScreen();
+    if (screen == nullptr) {
+      return false;
+    }
+
+    const QRect screenGeometry = screen->geometry();
+    const QRect availableGeometry = screen->availableGeometry();
+    const int topInset = availableGeometry.top() - screenGeometry.top();
+    const int bottomInset = screenGeometry.bottom() - availableGeometry.bottom();
+    const int rightInset = screenGeometry.right() - availableGeometry.right();
+    const int leftInset = availableGeometry.left() - screenGeometry.left();
+
+    if (topInset > 0) {
+      *position = QPoint(screenGeometry.right() - (topInset / 2), screenGeometry.top() + (topInset / 2));
+    } else if (bottomInset > 0) {
+      *position = QPoint(screenGeometry.right() - (bottomInset / 2), screenGeometry.bottom() - (bottomInset / 2));
+    } else if (rightInset > 0) {
+      *position = QPoint(screenGeometry.right() - (rightInset / 2), screenGeometry.bottom() - (rightInset / 2));
+    } else if (leftInset > 0) {
+      *position = QPoint(screenGeometry.left() + (leftInset / 2), screenGeometry.bottom() - (leftInset / 2));
+    } else {
+#if defined(_WIN32)
+      *position = QPoint(screenGeometry.right() - (DEFAULT_PANEL_THICKNESS / 2), screenGeometry.bottom() - (DEFAULT_PANEL_THICKNESS / 2));
+#else
+      *position = QPoint(screenGeometry.right() - (DEFAULT_PANEL_THICKNESS / 2), screenGeometry.top() + (DEFAULT_PANEL_THICKNESS / 2));
+#endif
+    }
+    return true;
+  }
+}  // namespace
 
 QtTrayMenu::QtTrayMenu(QObject *parent, const bool debug):
     QtTrayMenu(-1, nullptr, parent, debug) {
@@ -349,18 +390,23 @@ bool QtTrayMenu::positionMouseOverIcon() {
   }
 
   const QRect iconGeometry = trayIcon->geometry();
-  if (!iconGeometry.isValid()) {
-    qWarning("QtTrayMenu: tray icon geometry is unavailable");
+  QPoint targetPosition;
+  if (iconGeometry.isValid()) {
+    targetPosition = iconGeometry.center();
+  } else if (!fallbackTrayIconPosition(&targetPosition)) {
+    qWarning("QtTrayMenu: tray icon geometry and screen-edge fallback are unavailable");
     return false;
+  } else {
+    qWarning("QtTrayMenu: tray icon geometry is unavailable; using the system panel edge");
   }
 
   if (!mousePositionSaved) {
     savedMousePosition = QCursor::pos();
     mousePositionSaved = true;
   }
-  const QPoint targetPosition = iconGeometry.center();
   QCursor::setPos(targetPosition);
-  const bool positioned = QCursor::pos() == targetPosition;
+  const QPoint currentPosition = QCursor::pos();
+  const bool positioned = iconGeometry.isValid() ? iconGeometry.contains(currentPosition) : positionsAreClose(currentPosition, targetPosition);
   if (!positioned) {
     qWarning("QtTrayMenu: could not position the mouse over the tray icon");
   }
@@ -374,7 +420,7 @@ bool QtTrayMenu::restoreMousePosition() {
 
   QCursor::setPos(savedMousePosition);
   mousePositionSaved = false;
-  const bool restored = QCursor::pos() == savedMousePosition;
+  const bool restored = positionsAreClose(QCursor::pos(), savedMousePosition);
   if (!restored) {
     qWarning("QtTrayMenu: could not restore the saved mouse position");
   }

--- a/src/QtTrayMenu.cpp
+++ b/src/QtTrayMenu.cpp
@@ -3,7 +3,9 @@
  * @brief Definitions for Qt tray menu implemenation
  */
 // standard includes
+#include <chrono>
 #include <filesystem>
+#include <thread>
 
 // qt includes
 #include <QApplication>
@@ -22,10 +24,25 @@
 
 namespace {
   constexpr int DEFAULT_PANEL_THICKNESS = 24;
+  constexpr int CURSOR_POSITION_POLL_INTERVAL_MS = 10;
+  constexpr int CURSOR_POSITION_TIMEOUT_MS = 500;
   constexpr int CURSOR_POSITION_TOLERANCE = 2;
 
   bool positionsAreClose(const QPoint &first, const QPoint &second) {
     return (first - second).manhattanLength() <= CURSOR_POSITION_TOLERANCE;
+  }
+
+  bool waitForCursorPosition(const QPoint &targetPosition, const QRect &targetGeometry = {}) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(CURSOR_POSITION_TIMEOUT_MS);
+    do {
+      if (const QPoint currentPosition = QCursor::pos(); targetGeometry.isValid() ? targetGeometry.contains(currentPosition) : positionsAreClose(currentPosition, targetPosition)) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(CURSOR_POSITION_POLL_INTERVAL_MS));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    const QPoint currentPosition = QCursor::pos();
+    return targetGeometry.isValid() ? targetGeometry.contains(currentPosition) : positionsAreClose(currentPosition, targetPosition);
   }
 
   bool fallbackTrayIconPosition(QPoint *position) {
@@ -405,8 +422,7 @@ bool QtTrayMenu::positionMouseOverIcon() {
     mousePositionSaved = true;
   }
   QCursor::setPos(targetPosition);
-  const QPoint currentPosition = QCursor::pos();
-  const bool positioned = iconGeometry.isValid() ? iconGeometry.contains(currentPosition) : positionsAreClose(currentPosition, targetPosition);
+  const bool positioned = waitForCursorPosition(targetPosition, iconGeometry);
   if (!positioned) {
     qWarning("QtTrayMenu: could not position the mouse over the tray icon");
   }
@@ -419,8 +435,8 @@ bool QtTrayMenu::restoreMousePosition() {
   }
 
   QCursor::setPos(savedMousePosition);
+  const bool restored = waitForCursorPosition(savedMousePosition);
   mousePositionSaved = false;
-  const bool restored = positionsAreClose(QCursor::pos(), savedMousePosition);
   if (!restored) {
     qWarning("QtTrayMenu: could not restore the saved mouse position");
   }

--- a/src/QtTrayMenu.h
+++ b/src/QtTrayMenu.h
@@ -12,6 +12,7 @@
 // qt includes
 #include <QMenu>
 #include <QObject>
+#include <QPoint>
 #include <QString>
 #include <QSystemTrayIcon>
 
@@ -111,6 +112,18 @@ public:
   void clearMessageCallback() const;
 
   /**
+   * @brief Move the mouse cursor to the center of the tray icon.
+   * @return true if the tray icon has valid screen geometry and the cursor was moved
+   */
+  bool positionMouseOverIcon();
+
+  /**
+   * @brief Restore the mouse cursor position saved by positionMouseOverIcon().
+   * @return true if a saved position existed and the cursor was restored
+   */
+  bool restoreMousePosition();
+
+  /**
    * @brief Check if QtTrayMenu supports messages
    * @return true if messages can be shown
    */
@@ -150,6 +163,8 @@ private:
   bool blockingEventLoop = false;
   struct tray_menu *getTrayMenuItem(const QAction *action);
   mutable std::function<void()> notificationCallback = nullptr;
+  QPoint savedMousePosition;
+  bool mousePositionSaved = false;
 
 private slots:
   void onExitRequested();

--- a/src/tray.h
+++ b/src/tray.h
@@ -71,6 +71,18 @@ extern "C" {
   void tray_show_menu(void);
 
   /**
+   * @brief Position the mouse over the tray icon (for testing purposes).
+   * @return 0 on success, -1 if the tray icon geometry is unavailable.
+   */
+  int tray_position_mouse_over_icon(void);
+
+  /**
+   * @brief Restore the mouse position saved by tray_position_mouse_over_icon().
+   * @return 0 on success, -1 if no saved position exists or the cursor could not be restored.
+   */
+  int tray_restore_mouse_position(void);
+
+  /**
    * @brief Simulate a notification click, invoking the notification callback (for testing purposes).
    *
    * Triggers the stored notification callback as if the user clicked the notification.

--- a/src/tray_qt.cpp
+++ b/src/tray_qt.cpp
@@ -221,6 +221,20 @@ extern "C" {
     tray_qt::state().trayMenu->showMenu();
   }
 
+  int tray_position_mouse_over_icon(void) {
+    if (tray_qt::state().trayMenu == nullptr) {
+      return -1;
+    }
+    return tray_qt::state().trayMenu->positionMouseOverIcon() ? 0 : -1;
+  }
+
+  int tray_restore_mouse_position(void) {
+    if (tray_qt::state().trayMenu == nullptr) {
+      return -1;
+    }
+    return tray_qt::state().trayMenu->restoreMousePosition() ? 0 : -1;
+  }
+
   void tray_simulate_menu_item_click(int index) {
     if (tray_qt::state().trayMenu == nullptr) {
       return;

--- a/tests/unit/test_tray.cpp
+++ b/tests/unit/test_tray.cpp
@@ -127,9 +127,11 @@ protected:
   // Capture a screenshot while the tray menu is open, then dismiss and exit.
   void captureMenuStateAndExit(const char *screenshotName) const {
     const bool positionMouse = lizardbyte::common::is_github_actions();
+    int positionMouseResult = -1;
     if (positionMouse) {
       WaitForTrayReady();
-      ASSERT_EQ(tray_position_mouse_over_icon(), 0);
+      positionMouseResult = tray_position_mouse_over_icon();
+      EXPECT_EQ(positionMouseResult, 0);
     }
 
     std::atomic_bool exitRequested {false};
@@ -148,7 +150,10 @@ protected:
     }
     capture_thread.join();
     if (positionMouse) {
-      EXPECT_EQ(tray_restore_mouse_position(), 0);
+      const int restoreMouseResult = tray_restore_mouse_position();
+      if (positionMouseResult == 0) {
+        EXPECT_EQ(restoreMouseResult, 0);
+      }
     }
   }
 

--- a/tests/unit/test_tray.cpp
+++ b/tests/unit/test_tray.cpp
@@ -251,7 +251,7 @@ protected:
 
   void WaitForNotificationReady() const {
     WaitForTrayReady();
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__APPLE__)
     if (lizardbyte::common::is_github_actions()) {
       for (int i = 0; i < 40; i++) {
         tray_loop(0);

--- a/tests/unit/test_tray.cpp
+++ b/tests/unit/test_tray.cpp
@@ -126,6 +126,12 @@ protected:
 
   // Capture a screenshot while the tray menu is open, then dismiss and exit.
   void captureMenuStateAndExit(const char *screenshotName) const {
+    const bool positionMouse = lizardbyte::common::is_github_actions();
+    if (positionMouse) {
+      WaitForTrayReady();
+      ASSERT_EQ(tray_position_mouse_over_icon(), 0);
+    }
+
     std::atomic_bool exitRequested {false};
     std::thread capture_thread([this, screenshotName, &exitRequested]() {  // NOSONAR(cpp:S6168): C++17 has no std::jthread and this thread is explicitly joined
       EXPECT_TRUE(captureScreenshot(screenshotName));
@@ -141,6 +147,9 @@ protected:
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     capture_thread.join();
+    if (positionMouse) {
+      EXPECT_EQ(tray_restore_mouse_position(), 0);
+    }
   }
 
   static void hello_cb(struct tray_menu *) {
@@ -222,6 +231,7 @@ protected:
 
   void TearDown() override {
     ShutdownTray();
+    tray_restore_mouse_position();
     BaseTest::TearDown();
   }
 

--- a/tests/unit/test_tray_qt.cpp
+++ b/tests/unit/test_tray_qt.cpp
@@ -100,6 +100,7 @@ protected:
       trayRunning = false;
     }
 
+    tray_restore_mouse_position();
     tray_set_log_callback(nullptr);
     BaseTest::TearDown();
   }
@@ -163,6 +164,8 @@ TEST_F(TrayQtCoverageTest, SimulateMenuClickSkipsNonTriggerableActions) {
 TEST_F(TrayQtCoverageTest, ApiCallsAreNoOpsBeforeInit) {
   tray_update(trayData);
   tray_show_menu();
+  EXPECT_EQ(tray_position_mouse_over_icon(), -1);
+  EXPECT_EQ(tray_restore_mouse_position(), -1);
   tray_simulate_menu_item_click(0);
   tray_simulate_notification_click();
   PumpEvents();


### PR DESCRIPTION
<!---
    NOTE: DO NOT DELETE ANY COMMENTS OR SECTIONS OF THIS TEMPLATE.
    THEY ARE IMPORTANT FOR THE MAINTAINERS.
    IT IS OKAY TO LEAVE SECTIONS EMPTY AND BOXES UNCHECKED IF THEY DO NOT APPLY TO YOUR PR.
--->

## Description
<!--- Please include a summary of the changes. --->
Add tray_position_mouse_over_icon() and tray_restore_mouse_position() C API functions, backed by QtTrayMenu methods, to move and restore the cursor during testing. Use these in tests on GitHub Actions where mouse position matters for tray menu screenshots.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- If this PR fixes or closes any issues, please list them here. --->
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


#### Roadmap Issues
<!--- If this PR solves any roadmap issues (https://github.com/LizardByte/roadmap/issues), please list them here. --->
<!--- e.g. `- Closes https://github.com/LizardByte/roadmap/issues/1` --->


## Type of Change
<!--- Select the type of change your PR introduces. You can select multiple types. --->
- [ ] **feat**: New feature (non-breaking change which adds functionality)
- [ ] **fix**: Bug fix (non-breaking change which fixes an issue)
- [ ] **docs**: Documentation only changes
- [ ] **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc.)
- [ ] **refactor**: Code change that neither fixes a bug nor adds a feature
- [ ] **perf**: Code change that improves performance
- [x] **test**: Adding missing tests or correcting existing tests
- [ ] **build**: Changes that affect the build system or external dependencies
- [ ] **ci**: Changes to CI configuration files and scripts
- [ ] **chore**: Other changes that don't modify src or test files
- [ ] **revert**: Reverts a previous commit
- [ ] **BREAKING CHANGE**: Introduces a breaking change (can be combined with any type above)


## Checklist
<!--- Please check all applicable boxes. If a box does not apply, leave it unchecked. --->
- [x] Code follows the style guidelines of this project
- [x] Code has been self-reviewed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Code docstring/documentation-blocks for new or existing methods/components have been added or updated
- [x] Unit tests have been added or updated for any new or modified functionality

### AI Usage
<!--- Select the option that best describes AI usage in this PR (choose only one). --->
See our [AI usage policy](https://docs.lizardbyte.dev/latest/developers/contributing.html#ai-usage).

- [ ] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [x] **Heavy**: AI generated most or all of the code changes
